### PR TITLE
Merge revisions 5316:5335 from trunk to ogl-es:

### DIFF
--- a/source/Irrlicht/Android/CAndroidAssetReader.cpp
+++ b/source/Irrlicht/Android/CAndroidAssetReader.cpp
@@ -36,9 +36,12 @@ CAndroidAssetReader::~CAndroidAssetReader()
 		AAsset_close(Asset);
 }
 
-s32 CAndroidAssetReader::read(void* buffer, u32 sizeToRead)
+size_t CAndroidAssetReader::read(void* buffer, size_t sizeToRead)
 {
-	return AAsset_read(Asset, buffer, sizeToRead);
+	int readBytes = AAsset_read(Asset, buffer, sizeToRead);
+	if ( readBytes >= 0 )
+		return size_t(readBytes);
+	return 0;	// direct fd access is not possible (for example, if the asset is compressed). 
 }
       
 bool CAndroidAssetReader::seek(long finalPos, bool relativeMovement)

--- a/source/Irrlicht/Android/CAndroidAssetReader.h
+++ b/source/Irrlicht/Android/CAndroidAssetReader.h
@@ -33,7 +33,7 @@ namespace io
 		/** \param buffer Pointer to buffer where read bytes are written to.
 		\param sizeToRead Amount of bytes to read from the file.
 		\return How many bytes were read. */
-		virtual s32 read(void* buffer, u32 sizeToRead);
+		virtual size_t read(void* buffer, size_t sizeToRead);
 
 		//! Changes position in file
 		/** \param finalPos Destination position in the file.


### PR DESCRIPTION
- Fixed mipmaps rendering in Burning's driver.
- jpg loader can now load more jpg formats.
- SceneCollisionManager now using const camera pointers.
- Fix several bugs in multibyteToWString.
- Add clear function to strings.
- IReadFile::read and IWriteFile::write now returning size_t (like fread, fwrite in c-lib, but unfortunately unlike Android asset read function).


git-svn-id: svn://svn.code.sf.net/p/irrlicht/code/branches/ogl-es@5336 dfc29bdd-3216-0410-991c-e03cc46cb475